### PR TITLE
Change contract of lookup. Allow other outputs.

### DIFF
--- a/deta-lib/query.rkt
+++ b/deta-lib/query.rkt
@@ -266,7 +266,7 @@
                 (in-query conn q #:fetch batch-size)))
 
 (define/contract (lookup conn q)
-  (-> connection? dyn:query? (or/c false/c entity?))
+  (-> connection? dyn:query? (or/c false/c entity? number?))
   (for/first ([e (in-entities conn q)]) e))
 
 (begin-for-syntax


### PR DESCRIPTION
This pull request is a temporary fix.

The problem is that the output type in the contract of `lookup` is `(or/c false/c entity?)`.
Some queries will return database values: numbers, strings, dates etc.
I looked in `type.rkt` but there wasn't a "anything that can be returned"-type available.

The example that led me to look at `lookup` was:

```
(define (count-entries)
  (lookup db
          (~> (from entry #:as e)
              (select (count *)))))
```

Which doesn't work - since the query returns a number.

This PR just adds `number?` to the output type, but a more general type is needed.