### PR TITLE
Fix binary field type for PostgreSQL dialect

### DIFF
--- a/deta-lib/type.rkt
+++ b/deta-lib/type.rkt
@@ -130,7 +130,10 @@
     (struct binary-field ()
       #:methods gen:type
       [(define (type-contract _) bytes?)
-       (define (type-declaration _ dialect) "BLOB")
+       (define (type-declaration _ dialect)
+         (match dialect
+           ['sqlite3    "BLOB"]
+           ['postgresql "BYTEA"]))
        (define (type-load _ dialect v) v)
        (define (type-dump _ dialect v) v)])
 


### PR DESCRIPTION
PostgreSQL does not have a BLOB type, thus creating a schema for a Postgres connection gives a `type "blob" does not exist` error.
The equivalent type for BLOB is BYTEA.  
So I have added a match to make binary fields in PostgreSQL use the BYTEA type.

Fixes #26 