### PR TITLE
order by nulls first / last [wip]

### DIFF
--- a/deta-doc/deta.scrbl
+++ b/deta-doc/deta.scrbl
@@ -725,11 +725,16 @@ queries.
   (order-by query ([column maybe-direction] ...+))
   #:grammar
   [(maybe-direction (code:line)
-                    (code:line #:asc)
-                    (code:line #:desc)
-                    (code:line (unquote direction-expr)))]
+                    (code:line #:asc maybe-nulls-direction)
+                    (code:line #:desc maybe-nulls-direction)
+                    (code:line (unquote direction-expr) maybe-nulls-direction))
+   (maybe-nulls-direction (code:line)
+                          (code:line #:nulls-first)
+                          (code:line #:nulls-last)
+                          (code:line (unquote nulls-direction-expr)))]
   #:contracts
-  [(direction-expr (or/c 'asc 'desc))]]{
+  [(direction-expr (or/c 'asc 'desc))
+   (nulls-direction-expr (or/c 'nulls-first 'nulls-last))]]{
 
   Adds an @tt{ORDER BY} clause to @racket[query].  If @racket[query]
   already has one, then the new columns are appended to the existing
@@ -748,6 +753,11 @@ queries.
     (~> (from "users" #:as u)
         (order-by ([u.last-login ,direction])))
   ]
+
+  @interaction[
+    #:eval reference-eval
+    (~> (from "artworks" #:as a)
+        (order-by ([a.year #:desc #:nulls-last])))]
 }
 
 @defproc[(project-onto [q query?]
@@ -1281,6 +1291,7 @@ in mind!
   @item{The @racket[entity->hash] function.}
   @item{The @racketmodname[deta/reflect] module.}
   @item{Support for more PostgreSQL JSON operators.}
+  @item{Support for PostgreSQL @tt{NULLS FIRST} and @tt{NULLS LAST}.}
   @item{Operator arity errors are now enforced.}
 ]
 

--- a/deta-lib/private/ast.rkt
+++ b/deta-lib/private/ast.rkt
@@ -119,7 +119,7 @@
 (struct union clause (stmt)
   #:transparent)
 
-(struct order-by clause (pairs)
+(struct order-by clause (orderings)
   #:transparent)
 
 (struct returning clause (es)

--- a/deta-lib/private/dialect/standard.rkt
+++ b/deta-lib/private/dialect/standard.rkt
@@ -307,10 +307,10 @@
      (write-string "RETURNING ")
      (write-stmt es)]
 
-    [(order-by pairs)
+    [(order-by orderings)
      (write-string "ORDER BY ")
      (write/sep
-      pairs
+      orderings
       (match-lambda
         [(list e dir nulls-dir)
          (write-expr e)

--- a/deta-lib/private/dialect/standard.rkt
+++ b/deta-lib/private/dialect/standard.rkt
@@ -312,10 +312,15 @@
      (write/sep
       pairs
       (match-lambda
-        [(cons e dir)
+        [(list e dir nulls-dir)
          (write-expr e)
          (when (eq? dir 'desc)
-           (write-string " DESC"))]))]
+           (write-string " DESC"))
+         (when nulls-dir
+           (write-string " NULLS")
+           (case nulls-dir
+             [(nulls-first) (write-string " FIRST")]
+             [(nulls-last) (write-string " LAST")]))]))]
 
     [(union stmt)
      (write-string "UNION (")

--- a/deta-lib/private/query.rkt
+++ b/deta-lib/private/query.rkt
@@ -215,7 +215,7 @@
     [(query schema opts stmt)
      (query schema opts (struct-copy ast:select stmt [offset (ast:offset n)]))]))
 
-(define order-by-pair/c
+(define ordering/c
   (list/c ast:expr? (or/c 'asc 'desc) (or/c #f 'nulls-first 'nulls-last)))
 
 (define/contract (union q1 q2)
@@ -236,18 +236,18 @@
     [(query schema opts (and (struct* ast:select ([union u])) stmt))
      (query schema opts (struct-copy ast:select stmt [union (ast:union (union* (ast:union-stmt u) (query-stmt q2)))]))]))
 
-(define/contract (order-by q pair0 . pairs)
-  (-> select-query? order-by-pair/c order-by-pair/c ... query?)
+(define/contract (order-by q ordering0 . orderings)
+  (-> select-query? ordering/c ordering/c ... query?)
 
-  (define all-pairs
-    (cons pair0 pairs))
+  (define all-orderings
+    (cons ordering0 orderings))
 
   (match q
     [(query schema opts (and (struct* ast:select ([order-by #f])) stmt))
-     (query schema opts (struct-copy ast:select stmt [order-by (ast:order-by all-pairs)]))]
+     (query schema opts (struct-copy ast:select stmt [order-by (ast:order-by all-orderings)]))]
 
-    [(query schema opts (and (struct* ast:select ([order-by (ast:order-by existing-pairs)])) stmt))
-     (query schema opts (struct-copy ast:select stmt [order-by (ast:order-by (append existing-pairs all-pairs))]))]))
+    [(query schema opts (and (struct* ast:select ([order-by (ast:order-by existing-orderings)])) stmt))
+     (query schema opts (struct-copy ast:select stmt [order-by (ast:order-by (append existing-orderings all-orderings))]))]))
 
 (define/contract (project-onto q s)
   (-> query? schema? query?)

--- a/deta-lib/private/query.rkt
+++ b/deta-lib/private/query.rkt
@@ -216,7 +216,7 @@
      (query schema opts (struct-copy ast:select stmt [offset (ast:offset n)]))]))
 
 (define order-by-pair/c
-  (cons/c ast:expr? (or/c 'asc 'desc)))
+  (list/c ast:expr? (or/c 'asc 'desc) (or/c #f 'nulls-first 'nulls-last)))
 
 (define/contract (union q1 q2)
   (-> select-query? select-query? query?)

--- a/deta-lib/query.rkt
+++ b/deta-lib/query.rkt
@@ -418,7 +418,7 @@
              #:with e (with-syntax ([name (datum->syntax #'r (id->column-name (syntax->datum #'column)))])
                         #'(cons (ast:column name) value.e))))
 
-  (define-syntax-class q-order-pair
+  (define-syntax-class q-ordering
     #:literals (unquote)
     (pattern [column:q-expr (~optional
                              (~seq (~or (~and #:asc  dir-asc )
@@ -498,7 +498,7 @@
 
 (define-syntax (order-by stx)
   (syntax-parse stx
-    [(_ q:expr (e:q-order-pair ...+))
+    [(_ q:expr (e:q-ordering ...+))
      #'(dyn:order-by q e.e ...)]))
 
 (define-syntax (returning stx)

--- a/deta-lib/query.rkt
+++ b/deta-lib/query.rkt
@@ -420,14 +420,22 @@
 
   (define-syntax-class q-order-pair
     #:literals (unquote)
-    (pattern [column:q-expr (~or (~optional (~and #:asc  dir-asc ))
-                                 (~optional (~and #:desc dir-desc))
-                                 (~optional (unquote dir-expr:expr)))]
-             #:with dir (cond
-                          [(attribute dir-expr) #'dir-expr]
-                          [(attribute dir-desc) #''desc]
-                          [else #''asc])
-             #:with e #'(cons column.e dir))))
+    (pattern [column:q-expr (~optional (~or (~and #:asc  dir-asc )
+                                            (~and #:desc dir-desc)
+                                            (unquote dir-expr:expr)))
+                            (~optional (~or (~and #:nulls-first nulls-first*)
+                                            (~and #:nulls-last  nulls-last* )
+                                            (unquote nulls-expr:expr)))]
+             #:with dir
+             (cond [(attribute dir-expr) #'dir-expr]
+                   [(attribute dir-desc) #''desc]
+                   [else #''asc])
+             #:with nulls-dir
+             (cond [(attribute nulls-expr) #'nulls-expr]
+                   [(attribute nulls-first*) #''nulls-first]
+                   [(attribute nulls-last*) #''nulls-last]
+                   [else #'#f])
+             #:with e #'(list column.e dir nulls-dir))))
 
 (define-syntax (from stx)
   (syntax-parse stx

--- a/deta-lib/query.rkt
+++ b/deta-lib/query.rkt
@@ -420,12 +420,14 @@
 
   (define-syntax-class q-order-pair
     #:literals (unquote)
-    (pattern [column:q-expr (~optional (~or (~and #:asc  dir-asc )
-                                            (~and #:desc dir-desc)
-                                            (unquote dir-expr:expr)))
-                            (~optional (~or (~and #:nulls-first nulls-first*)
-                                            (~and #:nulls-last  nulls-last* )
-                                            (unquote nulls-expr:expr)))]
+    (pattern [column:q-expr (~optional
+                             (~seq (~or (~and #:asc  dir-asc )
+                                        (~and #:desc dir-desc)
+                                        (unquote dir-expr:expr))
+                                   (~optional
+                                    (~or (~and #:nulls-first nulls-first*)
+                                         (~and #:nulls-last  nulls-last* )
+                                         (unquote nulls-expr:expr)))))]
              #:with dir
              (cond [(attribute dir-expr) #'dir-expr]
                    [(attribute dir-desc) #''desc]

--- a/deta-test/deta/sql-postgresql.rkt
+++ b/deta-test/deta/sql-postgresql.rkt
@@ -434,7 +434,7 @@
        (define q (from "books" #:as b))
        (define result
          "SELECT * FROM books AS b ORDER BY b.title NULLS FIRST, b.year")
-       (check-emitted (order-by q ([b.title #:nulls-first] [b.year])) result)
+       (check-emitted (order-by q ([b.title #:asc #:nulls-first] [b.year])) result)
        (check-emitted (order-by q ([b.title #:asc ,'nulls-first] [b.year])) result)
        (check-emitted (order-by q ([b.title ,'asc ,'nulls-first] [b.year])) result)
        (check-emitted (order-by q ([b.title ,'asc #:nulls-first] [b.year])) result))
@@ -443,7 +443,7 @@
        (define q (from "books" #:as b))
        (define result
          "SELECT * FROM books AS b ORDER BY b.title NULLS LAST, b.year")
-       (check-emitted (order-by q ([b.title #:nulls-last] [b.year])) result))
+       (check-emitted (order-by q ([b.title #:asc #:nulls-last] [b.year])) result))
 
      (test-case "supports DESC NULLS LAST"
        (define q (from "books" #:as b))

--- a/deta-test/deta/sql-postgresql.rkt
+++ b/deta-test/deta/sql-postgresql.rkt
@@ -431,32 +431,35 @@
               (order-by ([(fragment 1)]))))))
 
      (test-case "supports NULLS FIRST"
-       (check-emitted
-        (~> (from "books" #:as b)
-            (order-by ([b.title #:nulls 'first]
-                       [b.year])))
-        "SELECT * FROM books AS b ORDER BY b.title NULLS FIRST, b.year"))
+       (define q (from "books" #:as b))
+       (define result
+         "SELECT * FROM books AS b ORDER BY b.title NULLS FIRST, b.year")
+       (check-emitted (order-by q ([b.title #:nulls-first] [b.year])) result)
+       (check-emitted (order-by q ([b.title #:asc ,'nulls-first] [b.year])) result)
+       (check-emitted (order-by q ([b.title ,'asc ,'nulls-first] [b.year])) result)
+       (check-emitted (order-by q ([b.title ,'asc #:nulls-first] [b.year])) result))
 
-     (test-case "supports NULLS LAST"
-       (check-emitted
-        (~> (from "books" #:as b)
-            (order-by ([b.title #:nulls 'last]
-                       [b.year])))
-        "SELECT * FROM books AS b ORDER BY b.title NULLS LAST, b.year"))
+     (test-case "supports NULLS LAST"  ; ASC NULLS LAST is actually Postgres' default
+       (define q (from "books" #:as b))
+       (define result
+         "SELECT * FROM books AS b ORDER BY b.title NULLS LAST, b.year")
+       (check-emitted (order-by q ([b.title #:nulls-last] [b.year])) result))
 
      (test-case "supports DESC NULLS LAST"
-       (check-emitted
-        (~> (from "books" #:as b)
-            (order-by ([b.title #:desc #:nulls 'last]
-                       [b.year])))
-        "SELECT * FROM books AS b ORDER BY b.title DESC NULLS LAST, b.year"))
+       (define q (from "books" #:as b))
+       (define result
+         "SELECT * FROM books AS b ORDER BY b.title DESC NULLS LAST, b.year")
+       (check-emitted (order-by q ([b.title #:desc #:nulls-last] [b.year])) result)
+       (check-emitted (order-by q ([b.title ,'desc ,'nulls-last] [b.year])) result)
+       (check-emitted (order-by q ([b.title #:desc ,'nulls-last] [b.year])) result)
+       (check-emitted (order-by q ([b.title ,'desc #:nulls-last] [b.year])) result))
 
-     (test-case "supports DESC NULLS LAST (dynamic ordering)"
-       (check-emitted
-        (~> (from "books" #:as b)
-            (order-by ([b.title 'desc #:nulls 'last]
-                       [b.year])))
-        "SELECT * FROM books AS b ORDER BY b.title DESC NULLS LAST, b.year"))
+     (test-case "errors out when given an invalid dynamic nulls direction"
+       (check-exn
+        exn:fail:contract?
+        (lambda _
+          (~> (from "books" #:as b)
+              (order-by ([b.title #:asc ,'foo]))))))
 
      (test-case "supports dynamic lists"
        (check-emitted

--- a/deta-test/deta/sql-postgresql.rkt
+++ b/deta-test/deta/sql-postgresql.rkt
@@ -430,6 +430,34 @@
           (~> (from "books" #:as b)
               (order-by ([(fragment 1)]))))))
 
+     (test-case "supports NULLS FIRST"
+       (check-emitted
+        (~> (from "books" #:as b)
+            (order-by ([b.title #:nulls 'first]
+                       [b.year])))
+        "SELECT * FROM books AS b ORDER BY b.title NULLS FIRST, b.year"))
+
+     (test-case "supports NULLS LAST"
+       (check-emitted
+        (~> (from "books" #:as b)
+            (order-by ([b.title #:nulls 'last]
+                       [b.year])))
+        "SELECT * FROM books AS b ORDER BY b.title NULLS LAST, b.year"))
+
+     (test-case "supports DESC NULLS LAST"
+       (check-emitted
+        (~> (from "books" #:as b)
+            (order-by ([b.title #:desc #:nulls 'last]
+                       [b.year])))
+        "SELECT * FROM books AS b ORDER BY b.title DESC NULLS LAST, b.year"))
+
+     (test-case "supports DESC NULLS LAST (dynamic ordering)"
+       (check-emitted
+        (~> (from "books" #:as b)
+            (order-by ([b.title 'desc #:nulls 'last]
+                       [b.year])))
+        "SELECT * FROM books AS b ORDER BY b.title DESC NULLS LAST, b.year"))
+
      (test-case "supports dynamic lists"
        (check-emitted
         (~> (from "books" #:as b)


### PR DESCRIPTION
I think I'd try implementing Postgres's `ORDER BY ... NULLS { FIRST | LAST }` if you think it's an appropriate feature in deta. I'm not exactly sure about the best api. My most immediate idea is in the test. Alternatively we might use `#:nulls-first` `#:nulls-last`, but that doesn't allow specifying it dynamically (like with `'asc` /  `'desc`). What do you think?